### PR TITLE
exclam: respond to !exclam command on the channel it was invoked

### DIFF
--- a/exclam.py
+++ b/exclam.py
@@ -32,11 +32,11 @@ class exclam(command):
         self.tmp_telegram_id = None
         self.tmp_tg_msg = None
 
-    async def command(self, message, telegram_id, user):
+    async def command(self, message, target, telegram_id, user):
         self.tmp_telegram_id = telegram_id
         res = await self.parse_command(message, nick=None)
         if isinstance(res, tuple):
-            await self.irc.send_msg(self.irc.service_user, None, res[0], user)
+            await self.irc.send_msg(self.irc.service_user, target, res[0], user)
             res = False
         return res, self.tmp_tg_msg
 

--- a/irc.py
+++ b/irc.py
@@ -412,7 +412,7 @@ class IRCHandler(object):
             message = self.tg.replace_mentions(message, me_nick='', received=False)
             telegram_id = self.iid_to_tid[tgt]
             if message[0] == '!':
-                cont, tg_msg = await self.exclam.command(message, telegram_id, user)
+                cont, tg_msg = await self.exclam.command(message, target, telegram_id, user)
             else:
                 tg_msg = await self.tg.telegram_client.send_message(telegram_id, message)
                 cont = True


### PR DESCRIPTION
If you call the command `!foo` while chatting in `#bobs_group`, the server will complain about `"Unknown command"`, but you'll only see that if you're talking with `TelegramServ`.

This commit makes the response for a command appear on the channel it was issued.
