### PR TITLE
move "Message id … deleted not in cache" into logger

### DIFF
--- a/telegram.py
+++ b/telegram.py
@@ -645,8 +645,7 @@ class TelegramHandler(object):
                 await self.relay_telegram_message(message=None, user=user, text=text, channel=chan)
                 self.to_volatile_cache(self.prev_id, deleted_id, text, user, chan, current_date())
             else:
-                text = 'Message id {} deleted not in cache'.format(deleted_id)
-                await self.relay_telegram_private_message(self.irc.service_user, text)
+                self.logger.info('Message id {} deleted not in cache'.format(deleted_id))
 
     async def handle_raw(self, update):
         self.logger.debug('Handling Telegram Raw Event: %s', pretty(update))


### PR DESCRIPTION
TelegramServ can get filled with warnings like

> Message id 012345 deleted not in cache

if you are in a channel/group that automatically deletes messages after a certain time, and the deleted message is not in cache.

Warn that in the logger.
With "info" severity, because that's not actually an issue, just something that can happen.