### PR TITLE
add capability negotiation and server-time

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -21,7 +21,7 @@ import tornado.ioloop
 
 from include import VERSION, CHAN_MAX_LENGTH, NICK_MAX_LENGTH, MAX_LINE
 from irc_replies import irc_codes
-from utils import chunks, set_replace, split_lines
+from utils import chunks, set_replace, split_lines, format_timestamp
 from service import service
 from exclam import exclam
 
@@ -35,6 +35,9 @@ VALID_IRC_NICK_CHARS         = VALID_IRC_NICK_FIRST_CHARS + string.digits + '-'
 # IRC Regular Expressions
 
 PREFIX          = r'(?ai)(:[^ ]+ +|)'
+IRC_CAP_LS_RX   = re.compile(PREFIX + r'CAP +(LS|LIST)( +.*)*')
+IRC_CAP_END_RX  = re.compile(PREFIX + r'CAP +(END)( +.*)*')
+IRC_CAP_REQ_RX  = re.compile(PREFIX + r'CAP +REQ( +:?(?P<extensions>[^\n]+))?')
 IRC_JOIN_RX     = re.compile(PREFIX + r'JOIN( +:| +|\n)(?P<channels>[^\n ]+|)')
 IRC_LIST_RX     = re.compile(PREFIX + r'LIST( +:| +|\n)(?P<channels>[^\n ]+|)')
 IRC_MODE_RX     = re.compile(PREFIX + r'MODE( +|\n)(?P<target>[^ ]+( +|\n)|)(?P<mode>[^ ]+( +|\n)|)(?P<arguments>[^\n]+|)')
@@ -119,6 +122,9 @@ class IRCHandler(object):
         self.irc_handlers = \
         (
             # pattern              handle           register_required   num_params_required
+            (IRC_CAP_LS_RX,   self.handle_irc_cap_ls,   False,            0),
+            (IRC_CAP_END_RX,  self.handle_irc_cap_end,  False,            0),
+            (IRC_CAP_REQ_RX,  self.handle_irc_cap_req,  False,            1),
             (IRC_PRIVMSG_RX,  self.handle_irc_privmsg,  True,             ALL_PARAMS),
             (IRC_PING_RX,     self.handle_irc_ping,     True,             ALL_PARAMS),
             (IRC_JOIN_RX,     self.handle_irc_join,     True,             ALL_PARAMS),
@@ -153,6 +159,34 @@ class IRCHandler(object):
         user.stream.write(command.encode(self.conf['char_out_encoding'], errors='replace'))
 
     # IRC handlers
+
+    async def handle_irc_cap_end(self, user, **args):
+        self.logger.debug('Handling CAP END')
+        user.asking_capabilities = False
+        await self.register(user)
+
+    async def handle_irc_cap_ls(self, user, **args):
+        self.logger.debug('Handling CAP LS')
+        if not user.registered:
+            user.asking_capabilities = True
+        await self.reply_command(user, SRV, 'CAP', ('*', 'LS', 'server-time message-tags'))
+
+    async def handle_irc_cap_req(self, user, extensions):
+        self.logger.debug('Handling CAP REQ: %s', extensions)
+        if not user.registered:
+            user.asking_capabilities = True
+        for extension in extensions.split():
+            if extension not in ['server-time', 'message-tags']:
+                await self.reply_command(user, SRV, 'CAP', (
+                  user.irc_username if user.irc_username else '*',
+                  'NAK',
+                  ' '.join(extensions.split())))
+                return
+        user.extensions.extend(extensions.split())
+        await self.reply_command(user, SRV, 'CAP', (
+            user.irc_username if user.irc_username else '*',
+            'ACK',
+            ' '.join(extensions.split())))
 
     async def handle_irc_pass(self, user, password):
         self.logger.debug('Handling PASS: %s', password)
@@ -435,6 +469,8 @@ class IRCHandler(object):
 
     # IRC functions
     async def register(self, user):
+        if user.asking_capabilities:
+            return
         self.logger.info('Registered IRC user "%s" from %s:%s', user.irc_nick, user.address, user.port)
 
         user.registered = True
@@ -443,7 +479,7 @@ class IRCHandler(object):
             await self.send_help(user)
         await self.check_telegram_auth(user)
 
-    async def send_msg(self, source, target, message, selfuser=None):
+    async def send_msg(self, source, target, message, selfuser=None, timestamp=None):
         messages = split_lines(message)
         tgt = target.lower() if target else ''
         is_chan = tgt in self.irc_channels.keys()
@@ -458,7 +494,7 @@ class IRCHandler(object):
                 irc_users = (u for u in self.users.values() if u.stream)
 
             for irc_user in irc_users:
-                await self.send_privmsg(irc_user, source_mask, target, msg)
+                await self.send_privmsg(irc_user, source_mask, target, msg, timestamp=timestamp)
 
     async def send_msg_others(self, source, target, message):
         source_mask = source.get_irc_mask()
@@ -472,11 +508,11 @@ class IRCHandler(object):
         for irc_user in irc_users:
             await self.send_privmsg(irc_user, source_mask, target, message)
 
-    async def send_action(self, source, target, message):
+    async def send_action(self, source, target, message, timestamp=None):
         action_message = '\x01ACTION {}\x01'.format(message)
-        await self.send_msg(source, target, action_message)
+        await self.send_msg(source, target, action_message, timestamp=timestamp)
 
-    async def send_privmsg(self, user, source_mask, target, msg):
+    async def send_privmsg(self, user, source_mask, target, msg, timestamp=None):
         # reference [1]
         src_mask = source_mask if source_mask else user.get_irc_mask()
         # target None (False): it's private, not a channel
@@ -486,7 +522,14 @@ class IRCHandler(object):
         # replace self @username and other mentions for self messages sent by this instance of irgramd
         msg = self.tg.replace_mentions(msg, user.irc_nick)
 
-        await self.send_irc_command(user, ':{} PRIVMSG {} :{}'.format(src_mask, tgt, msg))
+        tags = ''
+        if timestamp:
+            if 'server-time' in user.extensions:
+                tags = '@time=' + format_timestamp('%FT%T.000Z', 'UTC', timestamp) + ' '
+            else:
+                msg = '{} {}'.format(
+                  format_timestamp(self.conf['hist_timestamp_format'], self.conf['timezone'], timestamp), msg)
+        await self.send_irc_command(user, '{}:{} PRIVMSG {} :{}'.format(tags, src_mask, tgt, msg))
 
     async def reply_command(self, user, prfx, comm, params):
         prefix = self.gethostname(user) if prfx == SRV else prfx.get_irc_mask()
@@ -650,6 +693,7 @@ class IRCUser(object):
         self.irc_username = str(username)
         self.irc_realname = realname
         self.registered = False
+        self.asking_capabilities = False
         self.password = ''
         self.recv_pass = ''
         self.oper = False
@@ -657,6 +701,7 @@ class IRCUser(object):
         self.bot = None
         self.is_service = is_service
         self.close_reason = ''
+        self.extensions = []
 
     def get_irc_mask(self):
         return '{}!{}@{}'.format(self.irc_nick, self.irc_username, self.address)

--- a/irgramd
+++ b/irgramd
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     tornado.options.define('download_notice', default=10, metavar='SIZE (MiB)', help='Enable a notice when a download starts if its size is greater than SIZE, this is useful when a download takes some time to be completed')
     tornado.options.define('emoji_ascii', default=False, help='Replace emoji with ASCII emoticons')
     tornado.options.define('geo_url', type=str, default=None, metavar='TEMPLATE_URL', help='Use custom URL for showing geo latitude/longitude location, eg. OpenStreetMap')
-    tornado.options.define('hist_timestamp_format', metavar='DATETIME_FORMAT', help='Format string for timestamps in history, see https://www.strfti.me')
+    tornado.options.define('hist_timestamp_format', metavar='DATETIME_FORMAT', help='Format string for timestamps in history, if the client does not support server-time capability, see https://www.strfti.me')
     tornado.options.define('initial_help', default=True, help='Enable/disable initial help message from service user [TelegramServ]')
     tornado.options.define('irc_address', default='127.0.0.1', metavar='ADDRESS', help='Address to listen on for IRC')
     tornado.options.define('irc_nicks', type=str, multiple=True, metavar='nick,..', help='List of nicks allowed for IRC, if `pam` and optionally `pam_group` are set, PAM authentication will be used instead')

--- a/service.py
+++ b/service.py
@@ -23,6 +23,7 @@ class service(command):
         }
         self.ask_code = settings['ask_code']
         self.init_help = settings['initial_help']
+        self.timezone = settings['timezone']
         self.tg = telegram
         self.irc = telegram.irc
         self.tmp_ircnick = None
@@ -106,7 +107,7 @@ class service(command):
                     ty = self.tg.get_entity_type(dialog.entity, format='short')
                     pin = 'Yes' if dialog.pinned else 'No'
                     arch = 'Yes' if dialog.archived else 'No'
-                    last = compact_date(dialog.date, self.tg.timezone)
+                    last = compact_date(dialog.date, self.timezone)
                     if id == self.tg.id:
                         name_in_irc = self.tmp_ircnick
                     else:

--- a/telegram.py
+++ b/telegram.py
@@ -24,7 +24,7 @@ from telethon.errors.rpcerrorlist import SessionPasswordNeededError
 from include import CHAN_MAX_LENGTH, NICK_MAX_LENGTH
 from irc import IRCUser
 from utils import sanitize_filename, add_filename, is_url_equiv, extract_url, get_human_size, get_human_duration
-from utils import get_highlighted, fix_braces, format_timestamp, pretty, current_date, token
+from utils import get_highlighted, fix_braces, pretty, current_date, token
 import emoji2emoticon as e
 
 # Test IP table
@@ -57,8 +57,6 @@ class TelegramHandler(object):
         self.test_port  = settings['test_port']
         self.ask_code   = settings['ask_code']
         self.quote_len  = settings['quote_length']
-        self.hist_fmt   = settings['hist_timestamp_format']
-        self.timezone   = settings['timezone']
         self.geo_url    = settings['geo_url']
         if not settings['emoji_ascii']:
             e.emo = {}
@@ -667,8 +665,8 @@ class TelegramHandler(object):
         user = self.get_irc_user_from_telegram(msg.sender_id)
         mid = self.mid.num_to_id_offset(msg.peer_id, msg.id)
         text = await self.render_text(msg, mid, upd_to_webpend, user)
-        text_send = self.set_history_timestamp(text, history, msg.date, msg.action)
-        chan = await self.relay_telegram_message(msg, user, text_send)
+        chan = await self.relay_telegram_message(msg, user, text,
+            timestamp = msg.date if history else None)
         await self.history_search_volatile(history, msg.id)
 
         self.to_cache(msg.id, mid, msg.message, text, user, chan, msg.media)
@@ -701,17 +699,6 @@ class TelegramHandler(object):
         final_text = self.filters(final_text)
         return final_text
 
-    def set_history_timestamp(self, text, history, date, action):
-        if history and self.hist_fmt:
-            timestamp = format_timestamp(self.hist_fmt, self.timezone, date)
-            if action:
-                res = '{} {}'.format(text, timestamp)
-            else:
-                res = '{} {}'.format(timestamp, text)
-        else:
-            res = text
-        return res
-
     async def history_search_volatile(self, history, id):
         if history:
             if id in self.volatile_cache:
@@ -720,28 +707,27 @@ class TelegramHandler(object):
                     text = item['rendered_event']
                     chan = item['channel']
                     date = item['date']
-                    text_send = self.set_history_timestamp(text, history=True, date=date, action=False)
-                    await self.relay_telegram_message(None, user, text_send, chan)
+                    await self.relay_telegram_message(None, user, text_send, chan, timestamp = date if history else None)
 
-    async def relay_telegram_message(self, message, user, text, channel=None):
+    async def relay_telegram_message(self, message, user, text, channel=None, timestamp = None):
         private = (message and message.is_private) or (not message and not channel)
         action = (message and message.action)
         if private:
-            await self.relay_telegram_private_message(user, text, action)
+            await self.relay_telegram_private_message(user, text, action, timestamp=timestamp)
             chan = None
         else:
-            chan = await self.relay_telegram_channel_message(message, user, text, channel, action)
+            chan = await self.relay_telegram_channel_message(message, user, text, channel, action, timestamp=timestamp)
         return chan
 
-    async def relay_telegram_private_message(self, user, message, action=None):
+    async def relay_telegram_private_message(self, user, message, action=None, timestamp=None):
         self.logger.debug('Relaying Telegram Private Message: %s, %s', user, message)
 
         if action:
-            await self.irc.send_action(user, None, message)
+            await self.irc.send_action(user, None, message, timestamp=timestamp)
         else:
-            await self.irc.send_msg(user, None, message)
+            await self.irc.send_msg(user, None, message, timestamp=timestamp)
 
-    async def relay_telegram_channel_message(self, message, user, text, channel, action):
+    async def relay_telegram_channel_message(self, message, user, text, channel, action, timestamp=None):
         if message:
             entity = await message.get_chat()
             chan = await self.get_irc_channel_from_telegram_id(message.chat_id, entity)
@@ -751,9 +737,9 @@ class TelegramHandler(object):
         self.logger.debug('Relaying Telegram Channel Message: %s, %s', chan, text)
 
         if action:
-            await self.irc.send_action(user, chan, text)
+            await self.irc.send_action(user, chan, text, timestamp=timestamp)
         else:
-            await self.irc.send_msg(user, chan, text)
+            await self.irc.send_msg(user, chan, text, timestamp=timestamp)
 
         return chan
 


### PR DESCRIPTION
Whenever i get the backlog, the timestamp of the past message is displayed inside the message.

See this example: i get the last two messages, and the timestamp is displayed twice: once by the client (current timestamp) and once in the message (past timestamp). A third message, this time a real-time one, follows.

<img width="818" height="73" alt="scrot-1784847977" src="https://github.com/user-attachments/assets/fa6c95cb-95d9-4ef5-aea7-d7a5918b1438" />

Modern clients support the IRCv3 [server-time](https://ircv3.net/specs/extensions/server-time.html) capability, which was designed excatly for this case: for server to send backlog.  With this capability, backlog can be displayed by the client with its past timestamp.

Here, i get the last four messages, and the timestamp is displayed once, in the correct time. A fifth message, a real time one, follows:

<img width="810" height="99" alt="scrot-1784848067" src="https://github.com/user-attachments/assets/1f61cae2-85d1-40d4-82d1-03c5b76fe186" />

This patch adds support for the server-time capability, but fallbacks to the previous behavior if the client does not support it.